### PR TITLE
Allow custom 7.1 ROMs with OMS to not show warning

### DIFF
--- a/app/src/main/java/projekt/substratum/MainActivity.java
+++ b/app/src/main/java/projekt/substratum/MainActivity.java
@@ -716,7 +716,7 @@ public class MainActivity extends AppCompatActivity implements
 
         printFCMtoken();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && !References.getProp("ro.substratum.verified").equals("true")) {
             new AlertDialog.Builder(this)
                     .setTitle(R.string.api25_warning_title)
                     .setMessage(R.string.api25_warning_content)


### PR DESCRIPTION
Allow custom 7.1 ROMs with OMS to not show warning by adding ro.substratum.verifed to build.prop