### PR TITLE
Fix theme in Cache Initializer AlertDialog

### DIFF
--- a/app/src/main/java/projekt/substratum/config/References.java
+++ b/app/src/main/java/projekt/substratum/config/References.java
@@ -813,7 +813,7 @@ public class References {
         @Override
         protected void onPreExecute() {
             progress = new ProgressDialog(mContext, android.R.style
-                    .Theme_DeviceDefault_Dialog_Alert);
+                    .Theme_DeviceDefault_Light_Dialog_Alert);
 
             String parse = String.format(mContext.getString(R.string.on_demand_updating_text),
                     theme_name);


### PR DESCRIPTION
I've seen more material dark AlertDialogs, but let's start with this.