### PR TITLE
Check for bootlooping ROMs with isIncompatibleFirmware

### DIFF
--- a/app/src/main/java/projekt/substratum/MainActivity.java
+++ b/app/src/main/java/projekt/substratum/MainActivity.java
@@ -427,9 +427,7 @@ public class MainActivity extends AppCompatActivity implements
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && !References.checkOMS(
-                getApplicationContext()) && (
-                References.getProp("ro.build.version.security_patch").equals("2016-11-05") ||
-                References.getProp("ro.build.version.security_patch").equals("2016-12-05"))) {
+                getApplicationContext()) && References.isIncompatibleFirmware()) {
             new AlertDialog.Builder(this)
                     .setTitle(R.string.warning_title)
                     .setMessage(R.string.dangerous_warning_content)

--- a/app/src/main/java/projekt/substratum/config/References.java
+++ b/app/src/main/java/projekt/substratum/config/References.java
@@ -1079,9 +1079,10 @@ public class References {
         try {
             Date date = format.parse(currentPatch);
             long currentPatchTimestamp = date.getTime();
+
             return currentPatchTimestamp > NOVEMBER_PATCH_TIMESTAMP;
-        } catch (ParseException nfe) {
-            nfe.printStackTrace();
+        } catch (ParseException pe) {
+            pe.printStackTrace();
         }
 
         // Something bad happened. Aborting

--- a/app/src/main/java/projekt/substratum/config/References.java
+++ b/app/src/main/java/projekt/substratum/config/References.java
@@ -25,6 +25,8 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +40,8 @@ import projekt.substrate.ShowMeYourFierceEyes;
 import projekt.substratum.R;
 import projekt.substratum.util.CacheCreator;
 import projekt.substratum.util.Root;
+
+import static android.R.attr.format;
 
 public class References {
 
@@ -92,6 +96,8 @@ public class References {
     public static String settingsSubstratumDrawableName = "ic_settings_substratum";
     private static String metadataVersion = "Substratum_Plugin";
     private static String metadataThemeReady = "Substratum_ThemeReady";
+    // November security update(incompatible firmware) timestamp;
+    public static long NOVEMBER_PATCH_TIMESTAMP = 1478304000000L;
 
     // This method is used to check the version of the masquerade theme system
     public static int checkMasquerade(Context context) {
@@ -1064,5 +1070,21 @@ public class References {
             launch = new CacheCreator().initializeCache(mContext, theme_package);
             return null;
         }
+    }
+
+    public static boolean isIncompatibleFirmware() {
+
+        String currentPatch = References.getProp("ro.build.version.security_patch");
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
+        try {
+            Date date = format.parse(currentPatch);
+            long currentPatchTimestamp = date.getTime();
+            return currentPatchTimestamp > NOVEMBER_PATCH_TIMESTAMP;
+        } catch (ParseException nfe) {
+            nfe.printStackTrace();
+        }
+
+        // Something bad happened. Aborting
+        return false;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
 
     <string name="warning_title">WARNING!</string>
     <string name="dangerous_warning_content">Substratum has detected that it is running on a
-        BOOTLOOP-KNOWN FIRMWARE (November/December update N/N-MR1) and is strongly advising against
+        BOOTLOOP-KNOWN FIRMWARE (Update after November, N/N-MR1) and is strongly advising against
         applying any framework/Android System overlays.\n\nIf you choose to continue and end up in a
         bootloop, please flash the rescue archive found in "/storage/emulated/0/substratum/".
     </string>


### PR DESCRIPTION
Instead of checking against a known set of values, consider every firmware after the November Security update to be guilty until proven innocent.

When (if...) Google merges a fix for this, we will need to come back and change the boolean result into a switch case (or equivalent) between the affected dates.

I didn't test this on a real environment (device with affected timestamp and a substratum build). I tested the java output on an online emulator, then modified accordingly for use with substratum, and tested a debug build (=success).
