### PR TITLE
Check audio archived asset extensions before using them

### DIFF
--- a/app/src/main/java/projekt/substratum/config/References.java
+++ b/app/src/main/java/projekt/substratum/config/References.java
@@ -1199,6 +1199,14 @@ public class References {
         return false;
     }
 
+    // Credits for the method go to: http://www.journaldev.com/842/how-to-get-file-extension-in-java
+    public static String getFileExtension(File file) {
+        String fileName = file.getName();
+        if(fileName.lastIndexOf(".") != -1 && fileName.lastIndexOf(".") != 0)
+            return fileName.substring(fileName.lastIndexOf(".")+1);
+        else return "";
+    }
+
     // This method checks whether these are legitimate packages for Substratum
     @SuppressWarnings("unchecked")
     public static HashMap<String, String[]> getSubstratumPackages(Context context,

--- a/app/src/main/java/projekt/substratum/tabs/SoundPackager.java
+++ b/app/src/main/java/projekt/substratum/tabs/SoundPackager.java
@@ -132,7 +132,9 @@ public class SoundPackager extends Fragment {
             File[] fileArray = f.listFiles();
             ArrayList<String> archivedSounds = new ArrayList<>();
             for (File file : fileArray) {
-                archivedSounds.add(file.getName());
+                if (References.getFileExtension(file).equals("zip")) {
+                    archivedSounds.add(file.getName());
+                }
             }
             ArrayList<String> unarchivedSounds = new ArrayList<>();
             unarchivedSounds.add(getString(R.string.sounds_default_spinner));


### PR DESCRIPTION
It fixes an FC when a themer has bundled in not properly created assets in audio
(a case of a themer adding plain .ogg files under directories, while the correct way is to add .zip
files named after your sounds)

Report: https://plus.google.com/109278897311461141933/posts/CNmEJKYTMXe

Problems:
1. File name extension methods may be used elsewhere in the app, I didn't search for them (we should
consolidate them, if that's the case)
2. Checking for filename isn't the best way to check if a file is a zip but works for our case (bad
audio assets structure)
3. The audio tab will still be visible, because the "audio" folder still exists in assets (check
tab_checker)