### PR TITLE
Rootless createNewFolder & rootless checks

### DIFF
--- a/app/src/main/java/projekt/substratum/config/FileOperations.java
+++ b/app/src/main/java/projekt/substratum/config/FileOperations.java
@@ -139,6 +139,19 @@ public class FileOperations {
         }
     }
 
+    public static void createNewFolder(Context context, String destination) {
+        String dataDir = context.getDataDir().getAbsolutePath();
+        String externalDir = Environment.getExternalStorageDirectory().getAbsolutePath();
+        boolean needRoot = (!destination.startsWith(dataDir) && !destination.startsWith(externalDir) &&
+                !destination.startsWith("/system")) || (!destination.startsWith(dataDir) &&
+                !destination.startsWith(externalDir) && !destination.startsWith("/system"));
+        if (checkMasqueradeJobService(context) && needRoot) {
+            MasqueradeService.createNewFolder(context, destination);
+        } else {
+            createNewFolder(destination);
+        }
+    }
+
     public static void createNewFolder(String foldername) {
         Log.d(CREATE_LOG, "Using rootless operation to create " + foldername);
         File folder = new File(foldername);

--- a/app/src/main/java/projekt/substratum/config/FontManager.java
+++ b/app/src/main/java/projekt/substratum/config/FontManager.java
@@ -103,17 +103,23 @@ public class FontManager {
                 // Copy all the system fonts to /data/system/theme/fonts
                 File dataSystemThemeDir = new File("/data/system/theme");
                 if (!dataSystemThemeDir.exists()) {
-                    FileOperations.mountRWData();
-                    FileOperations.createNewFolder("/data/system/theme/");
+                    if (!checkMasqueradeJobService(context)) {
+                        FileOperations.mountRWData();
+                    }
+                    FileOperations.createNewFolder(context, "/data/system/theme/");
                 }
                 File dataSystemThemeFontsDir = new File("/data/system/theme/fonts");
                 if (!dataSystemThemeFontsDir.exists()) {
-                    FileOperations.mountRWData();
-                    FileOperations.createNewFolder("/data/system/theme/fonts");
+                    if (!checkMasqueradeJobService(context)) {
+                        FileOperations.mountRWData();
+                    }
+                    FileOperations.createNewFolder(context, "/data/system/theme/fonts");
                 } else {
                     FileOperations.delete(context, "/data/system/theme/fonts/");
-                    FileOperations.mountRWData();
-                    FileOperations.createNewFolder("/data/system/theme/fonts");
+                    if (!checkMasqueradeJobService(context)) {
+                        FileOperations.mountRWData();
+                    }
+                    FileOperations.createNewFolder(context, "/data/system/theme/fonts");
                 }
 
                 // Copy font configuration file (fonts.xml) to the working directory

--- a/app/src/main/java/projekt/substratum/config/MasqueradeService.java
+++ b/app/src/main/java/projekt/substratum/config/MasqueradeService.java
@@ -41,6 +41,7 @@ public class MasqueradeService {
     private static final String COMMAND_VALUE_MOVE = "move";
     private static final String COMMAND_VALUE_DELETE = "delete";
     private static final String COMMAND_VALUE_PROFILE = "profile";
+    private static final String COMMAND_VALUE_MKDIR = "mkdir";
 
     private static Intent getMasqueradeRootless(Context context) {
         Intent intent = new Intent();
@@ -184,6 +185,13 @@ public class MasqueradeService {
         masqIntent.putExtra(PROFILE_NAME_KEY, name);
         masqIntent.putExtra(DISABLE_LIST_KEY, toBeDisabled);
         masqIntent.putExtra(ENABLE_LIST_KEY, toBeEnabled);
+        context.startService(masqIntent);
+    }
+
+    public static void createNewFolder(Context context, String destination) {
+        Intent masqIntent = getMasqueradeRootless(context);
+        masqIntent.putExtra(PRIMARY_COMMAND_KEY, COMMAND_VALUE_MKDIR);
+        masqIntent.putExtra(DESTINATION_FILE_KEY, destination);
         context.startService(masqIntent);
     }
 }

--- a/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
@@ -735,8 +735,8 @@ public class ProfileFragment extends Fragment {
                     FileOperations.mountRW();
                     FileOperations.delete(getContext(), current_directory);
                     FileOperations.delete(getContext(), "/data/system/theme/");
-                    FileOperations.createNewFolder(current_directory);
-                    FileOperations.createNewFolder("/data/system/theme/");
+                    FileOperations.createNewFolder(getContext(), current_directory);
+                    FileOperations.createNewFolder(getContext(), "/data/system/theme/");
                     FileOperations.setPermissions(755, "/data/system/theme/");
 
                     File profile_apk_files = new File(Environment.getExternalStorageDirectory()
@@ -787,7 +787,7 @@ public class ProfileFragment extends Fragment {
                     }
 
                     FileOperations.delete(getContext(), "/data/system/theme/");
-                    FileOperations.createNewFolder("/data/system/theme/");
+                    FileOperations.createNewFolder(getContext(), "/data/system/theme/");
 
                     File profile_apk_files = new File(Environment.getExternalStorageDirectory()
                             .getAbsolutePath() + "/substratum/profiles/" +

--- a/app/src/main/java/projekt/substratum/util/BootAnimationUtils.java
+++ b/app/src/main/java/projekt/substratum/util/BootAnimationUtils.java
@@ -82,8 +82,10 @@ public class BootAnimationUtils {
                         Snackbar.LENGTH_LONG)
                         .show();
             }
-            FileOperations.mountROData();
-            FileOperations.mountRO();
+            if (!References.checkMasqueradeJobService(mContext)) {
+                FileOperations.mountROData();
+                FileOperations.mountRO();
+            }
         }
 
         @Override
@@ -296,8 +298,10 @@ public class BootAnimationUtils {
                                 "is decrypted, using dedicated theme bootanimation slot...");
                         themeDirectory = new File("/data/system/theme/");
                         if (!themeDirectory.exists()) {
-                            FileOperations.mountRWData();
-                            FileOperations.createNewFolder("/data/system/theme/");
+                            if (!References.checkMasqueradeJobService(mContext)) {
+                                FileOperations.mountRWData();
+                            }
+                            FileOperations.createNewFolder(mContext, "/data/system/theme/");
                         }
                     } else {
                         Log.d("BootAnimationUtils", "Data partition on the current device " +


### PR DESCRIPTION
1. Expands the "createNewFolder" method to include "/data/system/theme". 
2. Fixes most rogue "root access" dialogs (when the app should be used in "rootless" mode).