### PR TITLE
Change the showcase layout

### DIFF
--- a/app/src/main/java/projekt/substratum/adapters/ShowcaseItemAdapter.java
+++ b/app/src/main/java/projekt/substratum/adapters/ShowcaseItemAdapter.java
@@ -45,6 +45,12 @@ public class ShowcaseItemAdapter extends RecyclerView.Adapter<ShowcaseItemAdapte
                 .crossFade()
                 .into(viewHolder.imageView);
 
+        Glide.with(information.get(position).getContext())
+                .load(information.get(position).getThemeBackgroundImage())
+                .centerCrop()
+                .crossFade()
+                .into(viewHolder.backgroundImageView);
+
         viewHolder.themeName.setText(information.get(position).getThemeName());
         viewHolder.themeAuthor.setText(information.get(position).getThemeAuthor());
 
@@ -108,7 +114,7 @@ public class ShowcaseItemAdapter extends RecyclerView.Adapter<ShowcaseItemAdapte
         CardView cardView;
         TextView themeName, themeAuthor;
         ImageView themePricing;
-        ImageView imageView, wallpaper, sounds, fonts, bootanimations, overlays;
+        ImageView imageView, backgroundImageView, wallpaper, sounds, fonts, bootanimations, overlays;
 
         ViewHolder(View view) {
             super(view);
@@ -117,6 +123,7 @@ public class ShowcaseItemAdapter extends RecyclerView.Adapter<ShowcaseItemAdapte
             themeAuthor = (TextView) view.findViewById(R.id.theme_author);
             themePricing = (ImageView) view.findViewById(R.id.theme_pricing);
             imageView = (ImageView) view.findViewById(R.id.theme_icon);
+            backgroundImageView = (ImageView) view.findViewById(R.id.background_image);
             wallpaper = (ImageView) view.findViewById(R.id.theme_wallpapers);
             sounds = (ImageView) view.findViewById(R.id.theme_sounds);
             fonts = (ImageView) view.findViewById(R.id.theme_fonts);

--- a/app/src/main/java/projekt/substratum/model/ShowcaseItem.java
+++ b/app/src/main/java/projekt/substratum/model/ShowcaseItem.java
@@ -8,6 +8,7 @@ public class ShowcaseItem {
     private String themeName;
     private String themeLink;
     private String themeIcon;
+    private String themeBackgroundImage;
     private String themeAuthor;
     private String themePricing;
     private String themeSupport;
@@ -58,6 +59,14 @@ public class ShowcaseItem {
 
     public void setThemeIcon(String themeIcon) {
         this.themeIcon = themeIcon;
+    }
+
+    public String getThemeBackgroundImage() {
+        return themeBackgroundImage;
+    }
+
+    public void setThemeBackgroundImage(String themeBackgroundImage) {
+        this.themeBackgroundImage = themeBackgroundImage;
     }
 
     public String getThemeSupport() {

--- a/app/src/main/java/projekt/substratum/util/ReadCloudShowcaseFile.java
+++ b/app/src/main/java/projekt/substratum/util/ReadCloudShowcaseFile.java
@@ -46,6 +46,15 @@ public class ReadCloudShowcaseFile {
                     } catch (Exception e) {
                         // There is no image override tag
                     }
+
+                    String addon_backgroundimage = "";
+                    try {
+                        // Try to see if the entry has an image override tag <backgroundimage>
+                        addon_backgroundimage = eElement.getElementsByTagName("backgroundimage").item(0).
+                                getTextContent();
+                    } catch (Exception e) {
+                        // There is no image override tag
+                    }
                     String addon_pricing = eElement.getElementsByTagName("pricing").item(0).
                             getTextContent();
                     String addon_support = eElement.getElementsByTagName("support").item(0).
@@ -53,7 +62,7 @@ public class ReadCloudShowcaseFile {
 
                     if (addon_image.length() > 0) {
                         String[] finalArray = {addon_download_name, addon_download_link,
-                                addon_author, addon_pricing, addon_image, addon_support};
+                                addon_author, addon_pricing, addon_image, addon_backgroundimage, addon_support};
                         map.put(finalArray[0], finalArray[1]);
                         map.put(finalArray[0] + "-author", finalArray[2]);
                         map.put(finalArray[0] + "-pricing", finalArray[3]);

--- a/app/src/main/res/layout-v1/showcase_entry_card.xml
+++ b/app/src/main/res/layout-v1/showcase_entry_card.xml
@@ -1,126 +1,146 @@
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-                                    xmlns:card_view="http://schemas.android.com/apk/res-auto"
-                                    android:id="@+id/theme_card"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginEnd="10dp"
-                                    android:layout_marginStart="10dp"
-                                    android:layout_marginTop="15dp"
-                                    android:clickable="true"
-                                    android:foreground="?android:selectableItemBackground"
-                                    card_view:cardBackgroundColor="@color/main_screen_card_background"
-                                    card_view:cardCornerRadius="@dimen/main_screen_card_corner_radius"
-                                    card_view:cardElevation="@dimen/main_screen_card_elevation">
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="240dp"
+    android:orientation="vertical"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
 
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <android.support.v7.widget.CardView
+        android:id="@+id/theme_card"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:layout_marginBottom="4dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:layout_marginTop="4dp"
+        android:layout_weight="1"
+        card_view:cardCornerRadius="2dp"
+        card_view:cardElevation="1dp">
 
-        <ImageView
-            android:id="@+id/theme_icon"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:layout_margin="20dp"
-            android:scaleType="centerCrop"
-            android:src="@android:color/transparent"/>
+        <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
-        <ImageView
-            android:id="@+id/theme_pricing"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentTop="true"
-            android:layout_marginTop="-10dp"
-            android:paddingEnd="20dp"
-            android:scaleType="centerCrop"
-            android:src="@drawable/showcase_paid"/>
+            <ImageView
+                android:id="@+id/background_image"
+                android:layout_width="fill_parent"
+                android:layout_height="150dp"
+                android:layout_margin="0dp"
+                android:scaleType="centerCrop" />
 
-        <RelativeLayout
-            android:id="@+id/relativeLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_toEndOf="@id/theme_icon">
+            <ImageView
+                android:id="@+id/theme_pricing"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_above="@+id/theme_icon"
+                android:layout_alignParentStart="true"
+                android:layout_marginBottom="69dp"
+                android:layout_marginStart="6dp"
+                android:paddingEnd="20dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/showcase_paid" />
 
-            <TextView
-                android:id="@+id/theme_name"
+            <ImageView
+                android:id="@+id/theme_icon"
+                android:layout_width="75sp"
+                android:layout_height="75sp"
+                android:layout_alignBottom="@+id/relativeLayout"
+                android:layout_alignParentEnd="true"
+                android:layout_gravity="center_vertical"
+                android:layout_marginBottom="50dp"
+                android:layout_marginEnd="21dp" />
+
+            <RelativeLayout
+                android:id="@+id/relativeLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="end"
-                android:gravity="end"
-                android:paddingEnd="20dp"
-                android:text="THEME_NAME"
-                android:textAllCaps="true"
-                android:textColor="@color/main_screen_card_theme_title"
-                android:textSize="20sp"
-                android:textStyle="bold"/>
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/background_image"
+                android:layout_marginTop="20dp">
 
-            <TextView
-                android:id="@+id/theme_author"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/theme_name"
-                android:gravity="end"
-                android:paddingEnd="20dp"
-                android:text="THEME_AUTHOR"
-                android:textAllCaps="true"
-                android:textColor="@color/main_screen_card_theme_title"
-                android:textSize="14sp"/>
+                <TextView
+                    android:id="@+id/theme_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentStart="true"
+                    android:layout_marginBottom="5dp"
+                    android:layout_marginStart="17dp"
+                    android:layout_marginTop="2dp"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/theme_author"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignStart="@+id/theme_name"
+                    android:layout_below="@+id/theme_name"
+                    android:layout_marginEnd="15dp"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textSize="12sp" />
+            </RelativeLayout>
 
             <RelativeLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/theme_author"
-                android:paddingEnd="20dp"
-                android:paddingTop="3dp">
+                android:paddingEnd="10dp"
+                android:paddingBottom="20dp">
 
                 <ImageView
                     android:id="@+id/theme_wallpapers"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentEnd="true"
                     android:paddingStart="2.5dp"
-                    android:src="@drawable/nav_wallpapers"/>
+                    android:src="@drawable/nav_wallpapers"
+                    android:layout_alignParentBottom="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_marginEnd="10dp" />
 
                 <ImageView
                     android:id="@+id/theme_sounds"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_toStartOf="@id/theme_wallpapers"
                     android:paddingStart="2.5dp"
-                    android:src="@drawable/nav_sounds"/>
+                    android:src="@drawable/nav_sounds"
+                    android:layout_alignParentBottom="true"
+                    android:layout_toStartOf="@+id/theme_wallpapers" />
 
                 <ImageView
                     android:id="@+id/theme_fonts"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_toStartOf="@id/theme_sounds"
                     android:paddingStart="2.5dp"
-                    android:src="@drawable/nav_fonts"/>
+                    android:src="@drawable/nav_fonts"
+                    android:layout_alignParentBottom="true"
+                    android:layout_toStartOf="@+id/theme_sounds" />
 
                 <ImageView
                     android:id="@+id/theme_bootanimations"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_toStartOf="@id/theme_fonts"
                     android:paddingStart="2.5dp"
-                    android:src="@drawable/nav_bootanim"/>
+                    android:src="@drawable/nav_bootanim"
+                    android:layout_alignParentBottom="true"
+                    android:layout_toStartOf="@+id/theme_fonts" />
 
                 <ImageView
                     android:id="@+id/theme_overlays"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_toStartOf="@id/theme_bootanimations"
                     android:paddingStart="2.5dp"
-                    android:src="@drawable/nav_overlays"/>
+                    android:src="@drawable/nav_overlays"
+                    android:layout_alignParentBottom="true"
+                    android:layout_toStartOf="@+id/theme_bootanimations" />
 
             </RelativeLayout>
 
-
         </RelativeLayout>
 
-    </RelativeLayout>
+    </android.support.v7.widget.CardView>
 
-</android.support.v7.widget.CardView>
+</LinearLayout>


### PR DESCRIPTION
As of right now this works as in if you plug in a background image, the layout and "look"
is complete. The problem is that the database needs an update in order to successfully
pull in the card background image. This is something that Nick and Nathan will decide
on how to do it.

My suggestion is having themers contribute their own but if we can crawl the playstore listings
for the card background image then more power to you guys :-)

Ignore the second card, background image was hardcoded for preview
- http://i.imgur.com/7C7Tklq.png

[DO NOT MERGE WITHOUT UPDATING THE DATABASE]