### PR TITLE
Introduce Color Preview in Advanced UI

### DIFF
--- a/app/src/main/java/projekt/substratum/adapters/VariantsAdapter.java
+++ b/app/src/main/java/projekt/substratum/adapters/VariantsAdapter.java
@@ -1,0 +1,67 @@
+package projekt.substratum.adapters;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+
+import projekt.substratum.R;
+import projekt.substratum.model.VariantInfo;
+
+public class VariantsAdapter extends ArrayAdapter<VariantInfo> {
+
+    private final ArrayList<VariantInfo> variants;
+
+    public class ViewHolder {
+        TextView variantName;
+        ImageView variantHex;
+    }
+
+    public VariantsAdapter(Context context, ArrayList<VariantInfo> variants) {
+        super(context, R.layout.spinner_row, R.id.variant_name, variants);
+
+        this.variants = variants;
+    }
+
+    @Override
+    public View getDropDownView(int position, View convertView, ViewGroup parent) {
+        return getCustomView(position, convertView, parent);
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        return getCustomView(position, convertView, parent);
+    }
+
+    private View getCustomView(int position, View convertView, ViewGroup parent){
+        ViewHolder holder = null;
+
+        if(convertView == null) {
+            convertView = LayoutInflater.from(this.getContext())
+                    .inflate(R.layout.spinner_row, parent, false);
+
+            holder = new ViewHolder();
+            holder.variantName = (TextView) convertView.findViewById(R.id.variant_name);
+            holder.variantHex = (ImageView) convertView.findViewById(R.id.variant_hex);
+
+            convertView.setTag(holder);
+        } else {
+            holder = (ViewHolder) convertView.getTag();
+        }
+
+        VariantInfo item = getItem(position);
+        if (item!= null) {
+            holder.variantName.setText(item.getVariantName());
+            holder.variantHex.setBackgroundColor(Color.parseColor(item.getVariantHex()));
+        }
+
+        return convertView;
+    }
+}

--- a/app/src/main/java/projekt/substratum/config/References.java
+++ b/app/src/main/java/projekt/substratum/config/References.java
@@ -36,6 +36,7 @@ import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -1270,5 +1271,26 @@ public class References {
             launch = new CacheCreator().initializeCache(mContext, theme_package);
             return null;
         }
+    }
+
+    // This method parses a specific overlay resource file (.xml) and returns the specified value
+    // TODO: make it work with regex
+    // TODO: make it work with String[]
+    public static String getOverlayResource(File overlay_file, String resource_name) {
+        String hex = null;
+
+        try (BufferedReader br = new BufferedReader(new FileReader(overlay_file))) {
+            for (String line; (line = br.readLine()) != null; ) {
+                if (line.contains(resource_name)) {
+                    String[] split = line.substring(line.lastIndexOf("\">") + 2).split("<");
+                    hex = split[0];
+                }
+            }
+        } catch (IOException ioe) {
+            Log.e(References.SUBSTRATUM_LOG,
+                    "Unable to find " + resource_name + " in this overlay!");
+        }
+
+        return hex;
     }
 }

--- a/app/src/main/java/projekt/substratum/model/OverlaysInfo.java
+++ b/app/src/main/java/projekt/substratum/model/OverlaysInfo.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import projekt.substratum.adapters.VariantsAdapter;
 import projekt.substratum.config.References;
 
 public class OverlaysInfo implements Serializable {
@@ -25,7 +26,7 @@ public class OverlaysInfo implements Serializable {
     private String theme_name;
     private String name;
     private String package_name;
-    private ArrayAdapter<String> array;
+    private VariantsAdapter array;
     private ArrayAdapter<String> array2;
     private ArrayAdapter<String> array3;
     private ArrayAdapter<String> array4;
@@ -45,7 +46,7 @@ public class OverlaysInfo implements Serializable {
     private Boolean theme_oms;
 
     public OverlaysInfo(String theme_name, String name, String packageName, boolean isSelected,
-                        ArrayAdapter<String>
+                        VariantsAdapter
                                 adapter, ArrayAdapter<String>
                                 adapter2, ArrayAdapter<String>
                                 adapter3, ArrayAdapter<String>
@@ -112,7 +113,7 @@ public class OverlaysInfo implements Serializable {
         this.isSelected = isSelected;
     }
 
-    public ArrayAdapter<String> getSpinnerArray() {
+    public VariantsAdapter getSpinnerArray() {
         return array;
     }
 

--- a/app/src/main/java/projekt/substratum/model/VariantInfo.java
+++ b/app/src/main/java/projekt/substratum/model/VariantInfo.java
@@ -1,0 +1,24 @@
+package projekt.substratum.model;
+
+public class VariantInfo {
+    private String variant_name;
+    private String variant_hex;
+
+    public VariantInfo(String variant_name, String variant_hex) {
+        this.variant_name = variant_name;
+        this.variant_hex = variant_hex;
+    }
+
+    public String getVariantName() {
+        return variant_name;
+    }
+
+    public String getVariantHex() {
+        return variant_hex;
+    }
+
+    @Override
+    public String toString() {
+        return getVariantName();
+    }
+}

--- a/app/src/main/java/projekt/substratum/tabs/Overlays.java
+++ b/app/src/main/java/projekt/substratum/tabs/Overlays.java
@@ -67,11 +67,13 @@ import me.zhanghai.android.materialprogressbar.MaterialProgressBar;
 import projekt.substratum.InformationActivity;
 import projekt.substratum.R;
 import projekt.substratum.adapters.OverlaysAdapter;
+import projekt.substratum.adapters.VariantsAdapter;
 import projekt.substratum.config.ElevatedCommands;
 import projekt.substratum.config.FileOperations;
 import projekt.substratum.config.References;
 import projekt.substratum.config.ThemeManager;
 import projekt.substratum.model.OverlaysInfo;
+import projekt.substratum.model.VariantInfo;
 import projekt.substratum.services.NotificationButtonReceiver;
 import projekt.substratum.util.CacheCreator;
 import projekt.substratum.util.FloatingActionMenu;
@@ -999,7 +1001,7 @@ public class Overlays extends Fragment {
 
                 try {
                     try {
-                        ArrayList<String> type1a = new ArrayList<>();
+                        ArrayList<VariantInfo> type1a = new ArrayList<>();
                         ArrayList<String> type1b = new ArrayList<>();
                         ArrayList<String> type1c = new ArrayList<>();
                         ArrayList<String> type2 = new ArrayList<>();
@@ -1035,16 +1037,19 @@ public class Overlays extends Fragment {
                                                     "/type1a"))))) {
                                 String formatter = String.format(getString(R.string
                                         .overlays_variant_substitute), reader.readLine());
-                                type1a.add(formatter);
+                                // TODO: remove hardcoded default variant color
+                                type1a.add(new VariantInfo(formatter, "#FF0000"));
                             } catch (IOException e) {
                                 Log.e(References.SUBSTRATUM_LOG, "There was an error parsing " +
                                         "asset " +
                                         "file!");
-                                type1a.add(getString(R.string
-                                        .overlays_variant_default_1a));
+                                // TODO: remove hardcoded default variant color
+                                type1a.add(new VariantInfo(getString(R.string
+                                        .overlays_variant_default_1a), "#FF0000"));
                             }
                         } else {
-                            type1a.add(getString(R.string.overlays_variant_default_1a));
+                            // TODO: remove hardcoded default variant color
+                            type1a.add(new VariantInfo(getString(R.string.overlays_variant_default_1a), "#FF0000"));
                         }
 
                         if (typeArray.contains("type1b")) {
@@ -1110,7 +1115,21 @@ public class Overlays extends Fragment {
                                 if (!current.equals("res")) {
                                     if (current.contains(".xml")) {
                                         if (current.substring(0, 7).equals("type1a_")) {
-                                            type1a.add(current.substring(7, current.length() - 4));
+                                            File current_file = new File(mContext.getCacheDir().
+                                                    getAbsoluteFile() + "/SubstratumBuilder/"
+                                                    + theme_pid + "/assets/overlays/"
+                                                    + package_identifier + "/" + current);
+                                            // TODO: create new String[] getPossibleResourceNames and
+                                            // pass it to getOverlayResource instead of going one at
+                                            // a time.
+                                            String hex = References.getOverlayResource(current_file,
+                                                    "accent_device_default_light");
+                                            if (hex == null) {
+                                                hex = References.getOverlayResource(current_file,
+                                                        "material_deep_teal_500");
+                                            }
+                                            type1a.add(new VariantInfo(current.substring
+                                                    (7, current.length() - 4), hex));
                                         }
                                         if (current.substring(0, 7).equals("type1b_")) {
                                             type1b.add(current.substring(7, current.length() - 4));
@@ -1130,8 +1149,7 @@ public class Overlays extends Fragment {
                                 }
                             }
 
-                            ArrayAdapter<String> adapter1 = new ArrayAdapter<>(getActivity(),
-                                    android.R.layout.simple_spinner_dropdown_item, type1a);
+                            VariantsAdapter adapter1 = new VariantsAdapter(getActivity(), type1a);
                             ArrayAdapter<String> adapter2 = new ArrayAdapter<>(getActivity(),
                                     android.R.layout.simple_spinner_dropdown_item, type1b);
                             ArrayAdapter<String> adapter3 = new ArrayAdapter<>(getActivity(),

--- a/app/src/main/res/layout/spinner_row.xml
+++ b/app/src/main/res/layout/spinner_row.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/variant_hex"
+        android:layout_width="20dip"
+        android:layout_height="20dip"
+        android:layout_gravity="center_vertical" />
+
+    <CheckedTextView
+        android:id="@+id/variant_name"
+        style="?android:attr/spinnerDropDownItemStyle"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/listPreferredItemHeightSmall"
+        android:ellipsize="marquee"/>
+</LinearLayout>


### PR DESCRIPTION
Still needs:

* Spinner Layout fixes
* Rework "resource name" logic, create new String[] getPossibleResourceNames() method
which will return all the usual resource names used and pass them to getOverlayResource
which will need to go through each of them until it finds a match.
* The "resource name" search should expand to type1b, type1c, type2
* The "resource name" logic should be further guarded with null checks and fallbacks should be applied
by Substratum (empty ImageView? transparent?).
* Fix default accent color (currently hardcoded: #FF0000)