### PR TITLE
ThemeFragment: don't get so trigger happy

### DIFF
--- a/app/src/main/java/projekt/substratum/fragments/ThemeFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/ThemeFragment.java
@@ -343,12 +343,15 @@ public class ThemeFragment extends Fragment {
             ArrayList<String> removeList = new ArrayList<>();
             List<String> state1 = ThemeManager.listOverlays(1);
             // Overlays with non-existent targets
-            for (int i = 0; i < state1.size(); i++) {
-                Log.e("OverlayCleaner", "Target APK not found for \"" + state1.get(i) + "\" and " +
-                        "will be removed.");
-                removeList.add(state1.get(i));
+            // We need the null check because listOverlays never returns null, but empty
+            if (state1.size() > 0 && state1.get(0)!= null) {
+                for (int i = 0; i < state1.size(); i++) {
+                    Log.e("OverlayCleaner", "Target APK not found for \"" + state1.get(i) + "\" and " +
+                            "will be removed.");
+                    removeList.add(state1.get(i));
+                }
+                ThemeManager.uninstallOverlay(mContext, removeList);
             }
-            ThemeManager.uninstallOverlay(mContext, removeList);
             return null;
         }
     }


### PR DESCRIPTION
*ThemeManager.listOverlays(1)* will never return null but empty list because of this:
https://github.com/SubstratumResources/platform_frameworks_base/blob/1901186a091794a5da7b719542513c46675adb12/core/java/android/content/om/IOverlayManager.aidl#L30

Guard against that.

This solves rogue uninstall commands with empty ArrayLists getting sent to interfacer, producing the following output, each time Substratum was launched:
```
03-06 18:40:07.960 8001-8001/projekt.interfacer E/JobService: 'projekt.substratum' is not an authorized calling package, but the user has explicitly allowed all calling packages, validating calling package permissions...
03-06 18:40:07.961 8001-8001/projekt.interfacer E/JobService: Starting job with primary command 'uninstall', with job time: 1488818407958
```