### PR TITLE
Check if ROM has our system feature

### DIFF
--- a/app/src/main/java/projekt/substratum/config/References.java
+++ b/app/src/main/java/projekt/substratum/config/References.java
@@ -303,6 +303,11 @@ public class References {
         return prefs.getInt("oms_version", 0);
     }
 
+    public static boolean checkSubstratumFeature(Context context) {
+        // Using lowercase because that's how we defined it in our permissions xml
+        return context.getPackageManager().hasSystemFeature(SUBSTRATUM_THEME.toLowerCase());
+    }
+
     // This method is used to obtain the device ID of the current device (set up)
     @SuppressLint("HardwareIds")
     public static String getDeviceID(Context context) {

--- a/app/src/main/java/projekt/substratum/fragments/SettingsFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/SettingsFragment.java
@@ -89,7 +89,12 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         Preference themePlatform = getPreferenceManager().findPreference
                 ("theme_platform");
         if (References.checkOMS(getContext())) {
-            themePlatform.setSummary(getString(R.string.settings_about_oms_version_7));
+            String aboutThemePlatformSummary = getString(R.string.settings_about_oms_version_7);
+            if (!References.checkSubstratumFeature(getContext())) {
+                aboutThemePlatformSummary = aboutThemePlatformSummary + "\n"
+                        + getString(R.string.settings_about_oms_version_incompatible);
+            }
+            themePlatform.setSummary(aboutThemePlatformSummary);
         }
         themePlatform.setIcon(getContext().getDrawable(R.mipmap.projekt_icon));
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -877,4 +877,5 @@
     <string name="restore_fonts_button">Restore fonts</string>
 
     <string name="interfacer_not_authorized_toast">You shall not pass&#8230;</string>
+    <string name="settings_about_oms_version_incompatible">incompatible with Play Store</string>
 </resources>


### PR DESCRIPTION
We created our <feature name="projekt.substratum.theme" /> permission to allow the Play Store
to filter Substratum themes based on which theme platform the user's ROM is using
(OMS7 / legacy RRO2):
https://github.com/substratum/masquerade/blob/n-rootless/projekt.substratum.theme.xml

Until now we only checked for OMS version and assumed that the ROM has properly included our
custom permission.

This commit adds the official way of checking if the ROM actually provides said feature, producing
the following output in Settings if there is a problem:
http://i.imgur.com/TZoL32y.png