### PR TITLE
Update non-Theme Ready alert dialog

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,8 +61,8 @@
         if you already have them!
     </string>
     <string name="two_description">This theme supports Google\'s stock apps, the way they were made!
-        If you have Team Black Out\'s Google Apps installed, but would like to use this theme,
-        please remove them to regain support from the themer!
+        If you have Team Black Out\'s Google Apps installed then you do not need to remove them,
+        but they are not required for this theme!
     </string>
     <string name="tbo_dialog_proceed">Download</string>
     <string name="dynamic_gapps_dialog" translatable="false">Dynamic Gapps</string>


### PR DESCRIPTION
Changed the alert dialog description from telling users to remove Theme Ready if they have it installed. This is an unnecessary demand for themers who do not support Theme Ready, because it will not affect any themes which do not require it to be used. Theme Ready supports the themers, they don't need to change anything in their themes to support it.