### PR TITLE
Add a basic indicator for whether a ROM is supported or not

### DIFF
--- a/app/src/main/java/projekt/substratum/config/References.java
+++ b/app/src/main/java/projekt/substratum/config/References.java
@@ -1454,4 +1454,20 @@ public class References {
             return null;
         }
     }
+
+    // This method is used to determine whether a ROM is supported or not
+    public static Boolean checkROMsupport() {
+        return Build.PRODUCT.contains("abc") || Build.PRODUCT.contains("aicp") || Build.PRODUCT.contains("aex") || Build.PRODUCT.contains("aosip") ||
+                Build.PRODUCT.contains("beltz") || Build.PRODUCT.contains("benzo") || Build.PRODUCT.contains("broken") || Build.PRODUCT.contains("bliss") ||
+                Build.PRODUCT.contains("carbon") || Build.PRODUCT.contains("crdroid") || Build.PRODUCT.contains("citrus") || Build.PRODUCT.contains("cosmic") ||
+                Build.PRODUCT.contains("darkness") || Build.PRODUCT.contains("desolation") || Build.PRODUCT.contains("du") || Build.PRODUCT.contains("hazy") ||
+                Build.PRODUCT.contains("exodus") || Build.PRODUCT.contains("firehound") || Build.PRODUCT.contains("flash") || Build.PRODUCT.contains("xos") ||
+                Build.PRODUCT.contains("krexus") || Build.PRODUCT.contains("legend") || Build.PRODUCT.contains("liquid") || Build.PRODUCT.contains("maple") ||
+                Build.PRODUCT.contains("nitrogen") || Build.PRODUCT.contains("noob") || Build.PRODUCT.contains("nuclear") || Build.PRODUCT.contains("omni") ||
+                Build.PRODUCT.contains("pa") || Build.PRODUCT.contains("pn") || Build.PRODUCT.contains("rr") || Build.PRODUCT.contains("saosp") ||
+                Build.PRODUCT.contains("screw") || Build.PRODUCT.contains("tesla") || Build.PRODUCT.contains("tipsy") || Build.PRODUCT.contains("tuga") ||
+                Build.PRODUCT.contains("twisted") || Build.PRODUCT.contains("uberroms") || Build.PRODUCT.contains("validus") || Build.PRODUCT.contains("vanilla") ||
+                Build.PRODUCT.contains("vanir") || Build.PRODUCT.contains("velvet") || Build.PRODUCT.contains("vertex") || Build.PRODUCT.contains("xperience") ||
+                Build.PRODUCT.contains("yaosp") || Build.PRODUCT.contains("zephyr");
+    }
 }

--- a/app/src/main/java/projekt/substratum/fragments/SettingsFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/SettingsFragment.java
@@ -89,12 +89,15 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         systemPlatform.setSummary(
                 getString(R.string.android) + " " + References.getProp("ro.build.version.release") +
                         " (" + Build.ID + ")\n" +
-                        getString(R.string.device) + " " + Build.MODEL + " (" + Build.DEVICE + ")" +
-                        "\n" +
+                        getString(R.string.device) + " " + Build.MODEL + " (" + Build.DEVICE + ")" + "\n" +
                         getString(R.string.settings_about_oms_rro_version) + " " +
                         ((References.checkOMS(getContext())) ?
                                 getString(R.string.settings_about_oms_version_7) :
-                                getString(R.string.settings_about_rro_version_2))
+                                getString(R.string.settings_about_rro_version_2)) + "\n" +
+                        getString(R.string.rom_status) + " " +
+                        ((References.checkROMsupport()) ?
+                                getString(R.string.rom_status_supported) :
+                                getString(R.string.rom_status_unsupported))
         );
         systemPlatform.setIcon(References.grabAppIcon(getContext(), "com.android.systemui"));
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -807,7 +807,11 @@
     <string name="app_crash_title">%s keeps stopping&#8230;</string>
     <string name="app_crash_content">All enabled overlays for this app have been disabled.</string>
     <string name="dirty_flash_detected">Your firmware or ROM was updated without deleting user data (dirty flash). Substratum will reset itself to avoid bugs.</string>
-    
+
+    <string name="rom_status">rom:</string>
+    <string name="rom_status_supported">supported (⭐️)️</string>
+    <string name="rom_status_unsupported">not supported (😡)</string>
+
     <!-- Nav drawer -->
     <string name="nav_home">Theme packs</string>
     <string name="nav_overlays">Overlays</string>


### PR DESCRIPTION
Nick created a list of ROMs that were verified to have the necessary commits
to run Substratum properly with little to no jank. This 'mod' checks the
BUILD.PRODUCT prop against that list and determines which string to show in Settings.

This is done as simple as possible to not cause any inconvenience to the user. I do
advice it be kept like this because a dialog or anything beyond this will probably
annoy the user running an unsupported ROM.

If the user has a problem, the developers will ask for a screenshot of Settings
to see what the user is working with and this will show the developer at a glance
whether the ROM is on the list or not.

- I do not have access to all ROM build props so there's a chance there's wrong info
below. Please double check before merging