### PR TITLE
If something is not supported is......unsupported

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -791,7 +791,7 @@
 
     <string name="rom_status">support status:</string>
     <string name="rom_status_supported">%s is community supported!</string>
-    <string name="rom_status_unsupported">this rom is not known by the community yet&#8230;</string>
+    <string name="rom_status_unsupported">this rom is not community supported!</string>
     <string name="rom_status_network">internet check required&#8230;</string>
 
     <!-- Nav drawer -->


### PR DESCRIPTION
Let's not pretend like something is not supported. If a ROM is not on the supported list then is not supported. 

Quit this 'is not known'. Yes there is a rare chance that a ROM may be supported and not on the list but at that point is just because the developer of said ROM is lazy or doesn't care for Substratum in the first place. Let's not encourage laziness or mislead Substratum users because we want spare feelings here.