### PR TITLE
SettingsFragment: Make sure to catch network errors properly

### DIFF
--- a/app/src/main/java/projekt/substratum/fragments/SettingsFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/SettingsFragment.java
@@ -56,6 +56,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -779,7 +780,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 platformSummary.append(getString(R.string.rom_status))
                         .append(" ").append(supportedRom);
                 systemPlatform.setSummary(platformSummary.toString());
-            } else if (!References.isNetworkAvailable(getContext())) {
+            } else if (!References.isNetworkAvailable(getContext()) || result.equals("")) {
                 platformSummary.append(getString(R.string.rom_status)).append(" ").append(
                         getString(R.string.rom_status_network));
                 systemPlatform.setSummary(platformSummary.toString());
@@ -836,7 +837,9 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                             publishProgress((int) (total * 100 / fileLength));
                         output.write(data, 0, count);
                     }
-                } catch (Exception e) {
+                } catch (UnknownHostException exc) {
+                    return "";
+                } catch (Exception e){
                     return e.toString();
                 } finally {
                     try {


### PR DESCRIPTION
Currently all exceptions are passed as is to the onPostExecute method,
ignoring the case of potato internet connections where internet might
be connected but a random drop in the connection might cause a UnknownHostException
to be raised, causing something similar to this https://snag.gy/WE8Kha.jpg

To mitigate the issue, break away the UnknownHostException catch from the generic
Exception catch and return a blank string to indicate we got nothing, and handle the
blank string in the if else block in onPostExecute that actually sets the text