### PR TITLE
AndroidManifest: Add ACCESS_SERVICE permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="projekt.interfacer.permission.ACCESS_SERVICE" />
 
     <application
         android:name=".Substratum"


### PR DESCRIPTION
We modified the permission for connecting to JobService for CTS compatibility: https://substratum.review/#/c/414/

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>