### PR TITLE
Minor cleanup on profile fragment

### DIFF
--- a/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
@@ -257,7 +257,7 @@ public class ProfileFragment extends Fragment {
                         backupFunction.execute();
                         Log.d(References.SUBSTRATUM_LOG, selectedBackup.toString());
                         dialog.dismiss();
-                        backup_name.setText("");
+                        backup_name.getText().clear();
                     } else {
                         Toast.makeText(getContext(), R.string.profile_no_selection_warning,
                                 Toast.LENGTH_LONG).show();

--- a/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
@@ -280,24 +280,12 @@ public class ProfileFragment extends Fragment {
 
         // Handle Restores
 
-        list = new ArrayList<>();
-        list.add(getResources().getString(R.string.spinner_default_item));
-
         profile_selector = root.findViewById(R.id.restore_spinner);
 
-        // Now lets add all the located profiles
-        File f = new File(Environment.getExternalStorageDirectory().getAbsolutePath() +
-                "/substratum/profiles/");
-        File[] files = f.listFiles();
-        if (files != null) {
-            for (File inFile : files) {
-                if (inFile.isDirectory()) {
-                    list.add(inFile.getName());
-                }
-            }
-        }
-
+        list = new ArrayList<String>();
         adapter = new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_item, list);
+        RefreshSpinner();
+
         // Specify the layout to use when the list of choices appears
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         profile_selector.setAdapter(adapter);

--- a/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
+++ b/app/src/main/java/projekt/substratum/fragments/ProfileFragment.java
@@ -257,6 +257,7 @@ public class ProfileFragment extends Fragment {
                         backupFunction.execute();
                         Log.d(References.SUBSTRATUM_LOG, selectedBackup.toString());
                         dialog.dismiss();
+                        backup_name.setText("");
                     } else {
                         Toast.makeText(getContext(), R.string.profile_no_selection_warning,
                                 Toast.LENGTH_LONG).show();


### PR DESCRIPTION
ecc3213 (Harsh Shandilya, 2 minutes ago)
    ProfileFragment: Use EditView.getText().clear()

    This is the recommended method of setting an EditView to blank, setText("")
    is for TextView

41d8769 (Harsh Shandilya, 4 minutes ago)
    ProfileFragment: Fix code duplication

    When the profile_selector Spinner is instantiated, an ArrayList and
    ArrayAdapter are created for it to inflate values from. The code that
    populates the ArrayList was duplicated from the RefreshSpinner method. We
    create and assign the ArrayList and ArrayAdapter as blank entities then
    call the RefreshSpinner method to populate the ArrayList, allowing us to
    get rid of the duplicate code.

 da03e98 (Harsh Shandilya, 12 minutes ago)
    ProfileFragment: Clear profile name after saving

    Having the profile name linger after saving might suggest to some users
    that the operation was unsuccessful, despite the LunchBar telling them
    otherwise. Clear the name out to avoid the situation.