### PR TITLE
Clean up sendBadNotification in AndromedaBinderService

### DIFF
--- a/app/src/main/java/projekt/substratum/common/References.java
+++ b/app/src/main/java/projekt/substratum/common/References.java
@@ -361,13 +361,13 @@ public class References {
 
     public static void registerBroadcastReceivers(Context context) {
         try {
-            IntentFilter intentAppCrashed = new IntentFilter(APP_CRASHED);
             IntentFilter intentPackageAdded = new IntentFilter(PACKAGE_ADDED);
             intentPackageAdded.addDataScheme("package");
             IntentFilter intentPackageFullyRemoved = new IntentFilter(PACKAGE_FULLY_REMOVED);
             intentPackageFullyRemoved.addDataScheme("package");
 
             if (checkOMS(context)) {
+                IntentFilter intentAppCrashed = new IntentFilter(APP_CRASHED);
                 context.getApplicationContext().registerReceiver(
                         new AppCrashReceiver(), intentAppCrashed);
                 context.getApplicationContext().registerReceiver(
@@ -1714,7 +1714,7 @@ public class References {
         return false;
     }
 
-    public static PackageInfo getAndromedaPackage(Context context) {
+    private static PackageInfo getAndromedaPackage(Context context) {
         try {
             return context.getPackageManager().getPackageInfo(ANDROMEDA_PACKAGE, 0);
         } catch (Exception e) {

--- a/app/src/main/java/projekt/substratum/services/binder/AndromedaBinderService.java
+++ b/app/src/main/java/projekt/substratum/services/binder/AndromedaBinderService.java
@@ -125,12 +125,10 @@ public class AndromedaBinderService extends Service implements ServiceConnection
         NotificationManager mNotifyMgr =
                 (NotificationManager)
                         getApplicationContext().getSystemService(NOTIFICATION_SERVICE);
-
-        final NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getApplicationContext(), References.ANDROMEDA_NOTIFICATION_CHANNEL_ID);
         boolean isBadNotificationShowing = false;
-        StatusBarNotification[] notifications;
-        int badNotificationId = 2017;
+        final int badNotificationId = 2017;
         if (mNotifyMgr != null) {
+            StatusBarNotification[] notifications;
             notifications = mNotifyMgr.getActiveNotifications();
             for (StatusBarNotification notification : notifications) {
                 if (notification.getId() == badNotificationId) {
@@ -139,6 +137,7 @@ public class AndromedaBinderService extends Service implements ServiceConnection
             }
         }
         if (mNotifyMgr != null && !isBadNotificationShowing) {
+            final NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getApplicationContext(), References.ANDROMEDA_NOTIFICATION_CHANNEL_ID);
             mBuilder.setContentTitle(
                     getApplicationContext().getString(
                             R.string.andromeda_notification_title_negation));

--- a/app/src/main/java/projekt/substratum/services/binder/AndromedaBinderService.java
+++ b/app/src/main/java/projekt/substratum/services/binder/AndromedaBinderService.java
@@ -85,16 +85,12 @@ public class AndromedaBinderService extends Service implements ServiceConnection
                     }
 
                     if (!AndromedaService.checkServerActivity()) {
-                        sendBadNotification(new NotificationCompat.Builder(
-                                getApplicationContext(),
-                                References.DEFAULT_NOTIFICATION_CHANNEL_ID));
+                        sendBadNotification();
                         failed = true;
                     }
                 }
             } else {
-                sendBadNotification(new NotificationCompat.Builder(
-                        getApplicationContext(),
-                        References.DEFAULT_NOTIFICATION_CHANNEL_ID));
+                sendBadNotification();
             }
         }).start();
     }
@@ -125,11 +121,12 @@ public class AndromedaBinderService extends Service implements ServiceConnection
         Log.d(TAG, "Substratum has successfully unbinded with the Andromeda module.");
     }
 
-    public void sendBadNotification(NotificationCompat.Builder mBuilder) {
+    public void sendBadNotification() {
         NotificationManager mNotifyMgr =
                 (NotificationManager)
                         getApplicationContext().getSystemService(NOTIFICATION_SERVICE);
 
+        final NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getApplicationContext(), References.ANDROMEDA_NOTIFICATION_CHANNEL_ID);
         boolean isBadNotificationShowing = false;
         StatusBarNotification[] notifications;
         int badNotificationId = 2017;


### PR DESCRIPTION
Send notification to andromeda status channel & only create a notification builder when nessecary
