### PR TITLE
Remove unused notification channel from legacy

### DIFF
--- a/app/src/main/res/xml/legacy_preference_fragment.xml
+++ b/app/src/main/res/xml/legacy_preference_fragment.xml
@@ -122,12 +122,6 @@
             android:summary="@string/vibrate_on_compiled_description"
             android:title="@string/vibrate_on_compiled"/>
 
-        <Preference
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:key="manage_notifications"
-            android:title="@string/manage_notification_channel"/>
-
         <CheckBoxPreference
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
notification channels only work on Oreo
Oreo cannot be legacy so remove the setting