### PR TITLE
limit inclusion of unused resources in libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ android {
         targetSdkVersion 27
         versionCode 914
         versionName "nine hundred fourteen"
+        resConfigs "be", "cs", "de", "es-rES", "en", "fr", "hu", "it", "lt", "nl", "pl", "pt-rBR", "pt-rPT", "ru", "sk", "tr", "zh-rCN"
         buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${gitHash()}\""
     }


### PR DESCRIPTION
before 
9,05 MB (9.497.075 bytes)
after 
8,21 MB (8.614.461 bytes)

Note: If new translations are added the language code must be added here too