### PR TITLE
Deleted Samsung Software Update from blacklist

### DIFF
--- a/app/src/main/java/projekt/substratum/common/Resources.java
+++ b/app/src/main/java/projekt/substratum/common/Resources.java
@@ -96,7 +96,6 @@ public enum Resources {
     private static final String[] SAMSUNG_PERMISSION_BLACKLIST_PACKAGES = {
             "com.sec.android.app.music",
             "com.sec.android.app.voicenote",
-            "com.wssyncmldm",
             SUBSTRATUM_PACKAGE
     };
 


### PR DESCRIPTION
Software Update overlay doesn't apply by using sungstromeda. Deleting it from blacklist will make it working again. @Fahadali2315 introduced this for OMS but this overlay has always been working for me before the introduction of SwU in blacklist.