### PR TITLE
Add support for Magisk 17.4, improve directory checks

### DIFF
--- a/app/src/main/java/projekt/substratum/common/Internal.java
+++ b/app/src/main/java/projekt/substratum/common/Internal.java
@@ -135,9 +135,9 @@ public class Internal {
     public static final String BOOTANIMATION_DESCRIPTOR = "desc.txt";
     public static final String BOOTANIMATION = "bootanimation.zip";
     public static final String SHUTDOWNANIMATION = "shutdownanimation.zip";
-    public static final String BOOTANIMATION_LOCATION = (Systems.IS_PIE && References.checkMagisk()) ? References.MAGISK_MIRROR_MOUNT_POINT + "media/bootanimation.zip" : "/system/media/bootanimation.zip";
+    public static final String BOOTANIMATION_LOCATION = References.getPieMountPoint() + "/media/bootanimation.zip";
     public static final String BOOTANIMATION_BU = "bootanimation-backup.zip";
-    public static final String BOOTANIMATION_BU_LOCATION = (Systems.IS_PIE && References.checkMagisk()) ? References.MAGISK_MIRROR_MOUNT_POINT + "media/bootanimation-backup.zip" : "/system/media/bootanimation-backup.zip";
+    public static final String BOOTANIMATION_BU_LOCATION = References.getPieMountPoint() + "/media/bootanimation-backup.zip";
     public static final String VALIDATOR_CACHE = "ValidatorCache";
     public static final String VALIDATOR_CACHE_DIR = "/ValidatorCache/";
     public static final String SYSTEM_ADDON_DIR = "/system/addon.d/";


### PR DESCRIPTION
Added support for the new directory structure in Magisk 17.4, which stores its system mirror in /sbin/.magisk/system now.
Also fixed a bug where the bootanimation location was wrongly concatenated to the path without a path separator.
The Magisk install dir is detected automatically, and cached into its own variable. Also checkMagisk and isMagisk were rewritten to use this new path to detect Magisk support.